### PR TITLE
Feat#11: Todo 정렬 기능 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/controller/TodoController.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/controller/TodoController.kt
@@ -2,6 +2,7 @@ package org.hunzz.todoapplication.domain.todo.controller
 
 import org.hunzz.todoapplication.domain.todo.dto.request.AddTodoRequest
 import org.hunzz.todoapplication.domain.todo.service.TodoService
+import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
@@ -24,6 +26,10 @@ class TodoController(
 
     @GetMapping
     fun findAllTodos() = ResponseEntity.ok(todoService.findAllTodos())
+
+    @GetMapping("/{sort}/")
+    fun findAllTodosWithCriteria(@PathVariable sort: Sort.Direction, @RequestParam criteria: String) =
+        ResponseEntity.ok(todoService.findAllTodosWithCriteria(sort, criteria))
 
     @PostMapping
     fun addTodo(@RequestBody request: AddTodoRequest): ResponseEntity<Unit> =

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/dto/response/TodoResponse.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/dto/response/TodoResponse.kt
@@ -1,14 +1,18 @@
 package org.hunzz.todoapplication.domain.todo.dto.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.hunzz.todoapplication.domain.todo.model.Todo
 import java.time.LocalDateTime
 
 data class TodoResponse(
     val title: String,
     val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val date: LocalDateTime,
     val isCompleted: Boolean,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val createdAt: LocalDateTime,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val updatedAt: LocalDateTime
 ) {
     companion object {

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
@@ -4,6 +4,8 @@ import org.hunzz.todoapplication.domain.todo.dto.request.AddTodoRequest
 import org.hunzz.todoapplication.domain.todo.dto.response.TodoResponse
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
+import org.hunzz.todoapplication.global.exception.WrongCriteriaException
+import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,7 +16,15 @@ class TodoService(
 ) {
     @Transactional
     fun findAllTodos() =
-        todoRepository.findAll().map { TodoResponse.from(it) }
+        todoRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { TodoResponse.from(it) }
+
+    @Transactional
+    fun findAllTodosWithCriteria(sort: Sort.Direction, criteria: String) =
+        try {
+            (todoRepository.findAll(Sort.by(sort, criteria))).map { TodoResponse.from(it) }
+        } catch (e: Exception) {
+            throw WrongCriteriaException(criteria)
+        }
 
     @Transactional
     fun findTodo(todoId: Long) =

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
@@ -7,4 +7,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 class GlobalExceptionHandler {
     fun handleModelNotFoundException(e: ModelNotFoundException) =
         ResponseEntity.badRequest().body(e.message)
+
+    fun handleWrongCriteriaException(e: WrongCriteriaException) =
+        ResponseEntity.badRequest().body(e.message)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/WrongCriteriaException.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/WrongCriteriaException.kt
@@ -1,0 +1,4 @@
+package org.hunzz.todoapplication.global.exception
+
+class WrongCriteriaException(criteria: String) :
+    RuntimeException("Criteria '$criteria' is not suitable.")


### PR DESCRIPTION
#11 

- 전체 Todo 목록을 조회할 때, 정렬의 기준 기본값을 '작성일' 로 설정
- 정렬 방식(ASC/DESC)과 정렬 기준을 파라미터로 받는 findAllTodosWithCriteria 메서드 생성
- 예외 케이스 추가 (WrongCriteriaException)
- TodoResponse에서 LocalDateTime 자료형으로 선언된 멤버 변수들을 yyyy-MM-dd HH:mm:ss 형식으로 변환