### PR TITLE
Feat#19: Comment 수정/삭제 시 비밀번호 검증 로직 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/controller/CommentController.kt
@@ -1,12 +1,14 @@
 package org.hunzz.todoapplication.domain.comment.controller
 
 import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
+import org.hunzz.todoapplication.domain.comment.dto.request.DeleteCommentRequest
 import org.hunzz.todoapplication.domain.comment.service.CommentService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -21,7 +23,7 @@ class CommentController(
         return ResponseEntity.created(
             URI.create(
                 String.format(
-                    "/api/v1/todos/{todoId}/comments/%d",
+                    "/api/v1/todos/%d/comments/%d", todoId,
                     commentService.addComment(todoId, request)
                 )
             )
@@ -39,8 +41,12 @@ class CommentController(
     }
 
     @DeleteMapping("/{commentId}")
-    fun deleteComment(@PathVariable todoId: Long, @PathVariable commentId: Long): ResponseEntity<Unit> {
-        commentService.deleteComment(todoId, commentId)
+    fun deleteComment(
+        @PathVariable todoId: Long,
+        @PathVariable commentId: Long,
+        @RequestBody request: DeleteCommentRequest
+    ): ResponseEntity<Unit> {
+        commentService.deleteComment(todoId, commentId, request)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
@@ -1,0 +1,5 @@
+package org.hunzz.todoapplication.domain.comment.dto.request
+
+data class DeleteCommentRequest(
+    val password: String
+)

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -1,9 +1,11 @@
 package org.hunzz.todoapplication.domain.comment.service
 
 import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
+import org.hunzz.todoapplication.domain.comment.dto.request.DeleteCommentRequest
 import org.hunzz.todoapplication.domain.comment.repository.CommentRepository
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
+import org.hunzz.todoapplication.global.exception.WrongCommentPasswordException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,15 +23,21 @@ class CommentService(
 
     @Transactional
     fun updateComment(todoId: Long, commentId: Long, request: AddCommentRequest) =
-        getComment(commentId).update(request)
+        validateCommentPassword(commentId, request.password).run { getComment(commentId).update(request) }
+
 
     @Transactional
-    fun deleteComment(todoId: Long, commentId: Long) =
-        commentRepository.deleteById(commentId)
+    fun deleteComment(todoId: Long, commentId: Long, request: DeleteCommentRequest) =
+        validateCommentPassword(commentId, request.password).run { commentRepository.deleteById(commentId) }
 
     private fun getTodo(todoId: Long) =
         todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
 
     private fun getComment(commentId: Long) =
         commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment")
+
+    private fun validateCommentPassword(commentId: Long, password: String) {
+        val comment = getComment(commentId)
+        if (password != comment.password) throw WrongCommentPasswordException()
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
@@ -10,4 +10,7 @@ class GlobalExceptionHandler {
 
     fun handleWrongCriteriaException(e: WrongCriteriaException) =
         ResponseEntity.badRequest().body(e.message)
+
+    fun handleWrongCommentPasswordException(e: WrongCommentPasswordException) =
+        ResponseEntity.badRequest().body(e.message)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/WrongCommentPasswordException.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/WrongCommentPasswordException.kt
@@ -1,0 +1,4 @@
+package org.hunzz.todoapplication.global.exception
+
+class WrongCommentPasswordException :
+    RuntimeException("Password mis-match. Please try again.")


### PR DESCRIPTION
#19 

- CommentService 내 validateCommentPassword 메서드 생성
- CommentService의 updateComment, deleteComment 메서드에 비밀번호 검증 로직 추가
- Comment 삭제 시 비밀번호를 받기 위한 DeleteCommentRequest 클래스 생성
- 예외 케이스 추가 (WrongCommentPasswordException)