### PR TITLE
Feat#23: Todo 목록 조회 시 하위 댓글들도 조회하는 기능 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/response/CommentResponse.kt
@@ -1,12 +1,17 @@
 package org.hunzz.todoapplication.domain.comment.dto.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.hunzz.todoapplication.domain.comment.model.Comment
 import java.time.LocalDateTime
 
 data class CommentResponse(
     val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val createdAt: LocalDateTime,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val updatedAt: LocalDateTime
 ) {
-    fun from(comment: Comment) = CommentResponse(comment.content, comment.createdAt, comment.updatedAt)
+    companion object {
+        fun from(comment: Comment) = CommentResponse(comment.content, comment.createdAt, comment.updatedAt)
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/repository/CommentRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface CommentRepository : JpaRepository<Comment, Long> {}
+interface CommentRepository : JpaRepository<Comment, Long> {
+    fun findAllCommentsByTodoId(todoId: Long) : List<Comment>
+}

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -2,6 +2,7 @@ package org.hunzz.todoapplication.domain.comment.service
 
 import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
 import org.hunzz.todoapplication.domain.comment.dto.request.DeleteCommentRequest
+import org.hunzz.todoapplication.domain.comment.dto.response.CommentResponse
 import org.hunzz.todoapplication.domain.comment.repository.CommentRepository
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
@@ -15,6 +16,12 @@ class CommentService(
     private val todoRepository: TodoRepository,
     private val commentRepository: CommentRepository
 ) {
+    @Transactional
+    fun findAllCommentsByTodoId(todoId: Long): List<CommentResponse> {
+        println(todoId)
+        return commentRepository.findAllCommentsByTodoId(todoId).map { CommentResponse.from(it) }
+    }
+
     @Transactional
     fun addComment(todoId: Long, request: AddCommentRequest): Long {
         val todo = getTodo(todoId)

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/dto/response/TodoResponse.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/dto/response/TodoResponse.kt
@@ -1,6 +1,7 @@
 package org.hunzz.todoapplication.domain.todo.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import org.hunzz.todoapplication.domain.comment.dto.response.CommentResponse
 import org.hunzz.todoapplication.domain.todo.model.Todo
 import java.time.LocalDateTime
 
@@ -10,13 +11,22 @@ data class TodoResponse(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val date: LocalDateTime,
     val isCompleted: Boolean,
+    val comments: List<CommentResponse>,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val createdAt: LocalDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val updatedAt: LocalDateTime
 ) {
     companion object {
-        fun from(todo: Todo) =
-            TodoResponse(todo.title, todo.content, todo.date, todo.isCompleted, todo.createdAt, todo.updatedAt)
+        fun from(todo: Todo, comments: List<CommentResponse>) =
+            TodoResponse(
+                todo.title,
+                todo.content,
+                todo.date,
+                todo.isCompleted,
+                comments,
+                todo.createdAt,
+                todo.updatedAt
+            )
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
@@ -1,5 +1,6 @@
 package org.hunzz.todoapplication.domain.todo.service
 
+import org.hunzz.todoapplication.domain.comment.service.CommentService
 import org.hunzz.todoapplication.domain.todo.dto.request.AddTodoRequest
 import org.hunzz.todoapplication.domain.todo.dto.response.TodoResponse
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
@@ -12,23 +13,29 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TodoService(
-    private val todoRepository: TodoRepository
+    private val todoRepository: TodoRepository,
+    private val commentService: CommentService
 ) {
     @Transactional
     fun findAllTodos() =
-        todoRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { TodoResponse.from(it) }
+        todoRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+            .map { TodoResponse.from(it, getAllCommentsByTodoId(it.id!!)) }
 
     @Transactional
     fun findAllTodosWithCriteria(sort: Sort.Direction, criteria: String) =
         try {
-            (todoRepository.findAll(Sort.by(sort, criteria))).map { TodoResponse.from(it) }
+            (todoRepository.findAll(Sort.by(sort, criteria)))
+                .map { TodoResponse.from(it, getAllCommentsByTodoId(it.id!!)) }
         } catch (e: Exception) {
             throw WrongCriteriaException(criteria)
         }
 
     @Transactional
     fun findTodo(todoId: Long) =
-        TodoResponse.from(todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo"))
+        TodoResponse.from(
+            todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo"),
+            getAllCommentsByTodoId(todoId)
+        )
 
     @Transactional
     fun addTodo(request: AddTodoRequest) =
@@ -45,4 +52,7 @@ class TodoService(
     @Transactional
     fun deleteTodo(todoId: Long) =
         todoRepository.deleteById(todoId)
+
+    private fun getAllCommentsByTodoId(todoId: Long) =
+        commentService.findAllCommentsByTodoId(todoId)
 }


### PR DESCRIPTION
#23 

- TodoResponse의 속성에 comments 추가 (Comment 목록)
- TodoResponse의 from 메서드가 comments도 파라미터로 받게 설정
- TodoService에서 TodoResponse의 from을 사용하는 메서드들의 인수값 수정
- CommentService에 FindAllCommentsByTodoId 메서드 생성
- CommentRepository에 findAllByTodoId 메서드 생성
- TodoService에서 CommentService를 주입받아 Comment 목록을 가져오는 getAllCommentsByTodoId 메서드 생성
- CommentResponse에서 LocalDateTime 자료형으로 선언된 파라미터들을 yyyy-MM-dd HH:mm:ss 형식으로 변환