### PR TITLE
Refactor#26: 컨트롤러의 맵핑 URI 수정 및 코드 리팩토링

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/controller/CommentController.kt
@@ -14,39 +14,32 @@ import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
 @RestController
-@RequestMapping("/api/v1/todos/{todoId}/comments")
+@RequestMapping("/api/v1/comments")
 class CommentController(
     val commentService: CommentService
 ) {
     @PostMapping
-    fun addComment(@PathVariable todoId: Long, request: AddCommentRequest): ResponseEntity<Unit> {
+    fun addComment(request: AddCommentRequest): ResponseEntity<Unit> {
         return ResponseEntity.created(
-            URI.create(
-                String.format(
-                    "/api/v1/todos/%d/comments/%d", todoId,
-                    commentService.addComment(todoId, request)
-                )
-            )
+            URI.create(String.format("/api/v1/comments/%d", commentService.addComment(request)))
         ).build()
     }
 
     @PutMapping("/{commentId}")
     fun updateComment(
-        @PathVariable todoId: Long,
         @PathVariable commentId: Long,
         request: AddCommentRequest
     ): ResponseEntity<Unit> {
-        commentService.updateComment(todoId, commentId, request)
+        commentService.updateComment(commentId, request)
         return ResponseEntity.ok().build()
     }
 
     @DeleteMapping("/{commentId}")
     fun deleteComment(
-        @PathVariable todoId: Long,
         @PathVariable commentId: Long,
         @RequestBody request: DeleteCommentRequest
     ): ResponseEntity<Unit> {
-        commentService.deleteComment(todoId, commentId, request)
+        commentService.deleteComment(commentId, request)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
@@ -4,6 +4,7 @@ import org.hunzz.todoapplication.domain.comment.model.Comment
 import org.hunzz.todoapplication.domain.todo.model.Todo
 
 data class AddCommentRequest(
+    val todoId: Long,
     val content: String,
     val password: String
 ) {

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
@@ -1,5 +1,6 @@
 package org.hunzz.todoapplication.domain.comment.dto.request
 
 data class DeleteCommentRequest(
+    val todoId: Long,
     val password: String
 )

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -23,19 +23,20 @@ class CommentService(
     }
 
     @Transactional
-    fun addComment(todoId: Long, request: AddCommentRequest): Long {
-        val todo = getTodo(todoId)
+    fun addComment(request: AddCommentRequest): Long {
+        val todo = getTodo(request.todoId)
         return commentRepository.save(request.to(todo)).id!!
     }
 
     @Transactional
-    fun updateComment(todoId: Long, commentId: Long, request: AddCommentRequest) =
-        validateCommentPassword(commentId, request.password).run { getComment(commentId).update(request) }
-
+    fun updateComment(commentId: Long, request: AddCommentRequest) =
+        validate(request.todoId, commentId, request.password)
+            .run { getComment(commentId).update(request) }
 
     @Transactional
-    fun deleteComment(todoId: Long, commentId: Long, request: DeleteCommentRequest) =
-        validateCommentPassword(commentId, request.password).run { commentRepository.deleteById(commentId) }
+    fun deleteComment(commentId: Long, request: DeleteCommentRequest) =
+        validate(request.todoId, commentId, request.password)
+            .run { commentRepository.deleteById(commentId) }
 
     private fun getTodo(todoId: Long) =
         todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
@@ -43,8 +44,9 @@ class CommentService(
     private fun getComment(commentId: Long) =
         commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment")
 
-    private fun validateCommentPassword(commentId: Long, password: String) {
+    private fun validate(todoId: Long, commentId: Long, password: String) {
         val comment = getComment(commentId)
-        if (password != comment.password) throw WrongCommentPasswordException()
+        if (!todoRepository.existsById(todoId)) throw ModelNotFoundException("Todo")
+        else if (password != comment.password) throw WrongCommentPasswordException()
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
@@ -31,27 +31,23 @@ class TodoService(
         }
 
     @Transactional
-    fun findTodo(todoId: Long) =
-        TodoResponse.from(
-            todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo"),
-            getAllCommentsByTodoId(todoId)
-        )
+    fun findTodo(todoId: Long) = TodoResponse.from(getTodo(todoId), getAllCommentsByTodoId(todoId))
 
     @Transactional
     fun addTodo(request: AddTodoRequest) =
         todoRepository.save(request.to()).id!!
 
     @Transactional
-    fun updateTodo(todoId: Long, request: AddTodoRequest) =
-        (todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")).update(request)
+    fun updateTodo(todoId: Long, request: AddTodoRequest) = getTodo(todoId).update(request)
 
     @Transactional
-    fun updateTodoCompletion(todoId: Long) =
-        (todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")).update()
+    fun updateTodoCompletion(todoId: Long) = getTodo(todoId).update()
 
     @Transactional
     fun deleteTodo(todoId: Long) =
         todoRepository.deleteById(todoId)
+
+    private fun getTodo(todoId: Long) = todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
 
     private fun getAllCommentsByTodoId(todoId: Long) =
         commentService.findAllCommentsByTodoId(todoId)


### PR DESCRIPTION
#26 

- TodoRepository로부터 Todo를 찾아오는 내부 메서드 getTodo를 TodoService에 만들어 중복 코드 제거
- CommentController의 맵핑 URI를 /api/v1/comments로 변경
- CommentController에서 todoId를 PathVariable로 받지 않고, Request 객체에 넣어서 받기
    - 위 사항에 따른 CommentController, CommentService의 파라미터 수정
- CommentService의 내부 메서드 validatePassword를 validate로 이름 변경
    - 패스워드 뿐만 아니라 todoId의 유효성 검사도 실시