### PR TITLE
Bugfix#28: Todo에 Comment가 추가된 경우 삭제가 되지 않는 에러 해결

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/repository/CommentRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findAllCommentsByTodoId(todoId: Long) : List<Comment>
+    fun deleteAllCommentsByTodoId(todoId: Long)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -38,6 +38,9 @@ class CommentService(
         validate(request.todoId, commentId, request.password)
             .run { commentRepository.deleteById(commentId) }
 
+    @Transactional
+    fun deleteCommentsByTodoId(todoId: Long) = commentRepository.deleteAllCommentsByTodoId(todoId)
+
     private fun getTodo(todoId: Long) =
         todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
 

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
@@ -45,10 +45,13 @@ class TodoService(
 
     @Transactional
     fun deleteTodo(todoId: Long) =
-        todoRepository.deleteById(todoId)
+        deleteAllCommentsByTodoId(todoId).run { todoRepository.deleteById(todoId) }
 
     private fun getTodo(todoId: Long) = todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
 
     private fun getAllCommentsByTodoId(todoId: Long) =
         commentService.findAllCommentsByTodoId(todoId)
+
+    private fun deleteAllCommentsByTodoId(todoId: Long) =
+        commentService.deleteCommentsByTodoId(todoId)
 }


### PR DESCRIPTION
- CommentRepository와 CommentService에 deleteAllCommentsByTodoId 메서드 생성
- deleteAllCommentsByTodoId 메서드를 통해 todoId에 해당하는 모든 Comments 삭제
- TodoService에서 이미 주입받은 CommentService 객체를 활용해 deleteAllCommentsByTodoId 메서드 생성