### PR TITLE
Feat/#39: Member와 Comment 사이에 연관관계 설정 + Comment 수정/삭제 시, memberId도 받아오는 로직 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
@@ -1,12 +1,14 @@
 package org.hunzz.todoapplication.domain.comment.dto.request
 
 import org.hunzz.todoapplication.domain.comment.model.Comment
+import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.todo.model.Todo
 
 data class AddCommentRequest(
+    val memberId: Long,
     val todoId: Long,
     val content: String,
     val password: String
 ) {
-    fun to(todo: Todo) = Comment(content, password, todo)
+    fun to(todo: Todo, member: Member) = Comment(content, password, todo, member)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/DeleteCommentRequest.kt
@@ -1,6 +1,7 @@
 package org.hunzz.todoapplication.domain.comment.dto.request
 
 data class DeleteCommentRequest(
+    val memberId: Long,
     val todoId: Long,
     val password: String
 )

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/response/CommentResponse.kt
@@ -5,6 +5,7 @@ import org.hunzz.todoapplication.domain.comment.model.Comment
 import java.time.LocalDateTime
 
 data class CommentResponse(
+    val memberName: String,
     val content: String,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     val createdAt: LocalDateTime,
@@ -12,6 +13,7 @@ data class CommentResponse(
     val updatedAt: LocalDateTime
 ) {
     companion object {
-        fun from(comment: Comment) = CommentResponse(comment.content, comment.createdAt, comment.updatedAt)
+        fun from(comment: Comment) =
+            CommentResponse(comment.member.name, comment.content, comment.createdAt, comment.updatedAt)
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/model/Comment.kt
@@ -2,6 +2,7 @@ package org.hunzz.todoapplication.domain.comment.model
 
 import jakarta.persistence.*
 import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
+import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.todo.model.Todo
 import org.hunzz.todoapplication.global.entity.BaseEntity
 
@@ -10,7 +11,8 @@ import org.hunzz.todoapplication.global.entity.BaseEntity
 class Comment(
     content: String,
     password: String,
-    todo: Todo
+    todo: Todo,
+    member: Member
 ) : BaseEntity() {
     @Id
     @Column(name = "comment_id")
@@ -26,6 +28,10 @@ class Comment(
     @ManyToOne
     @JoinColumn(name = "todo_id")
     var todo: Todo = todo
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    var member: Member = member
 
     fun update(request: AddCommentRequest) {
         this.content = request.content

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -4,6 +4,7 @@ import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
 import org.hunzz.todoapplication.domain.comment.dto.request.DeleteCommentRequest
 import org.hunzz.todoapplication.domain.comment.dto.response.CommentResponse
 import org.hunzz.todoapplication.domain.comment.repository.CommentRepository
+import org.hunzz.todoapplication.domain.member.repository.MemberRepository
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
 import org.hunzz.todoapplication.global.exception.WrongCommentPasswordException
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CommentService(
+    private val memberRepository: MemberRepository,
     private val todoRepository: TodoRepository,
     private val commentRepository: CommentRepository
 ) {
@@ -24,22 +26,26 @@ class CommentService(
 
     @Transactional
     fun addComment(request: AddCommentRequest): Long {
+        val member = getMember(request.memberId)
         val todo = getTodo(request.todoId)
-        return commentRepository.save(request.to(todo)).id!!
+        return commentRepository.save(request.to(todo, member)).id!!
     }
 
     @Transactional
     fun updateComment(commentId: Long, request: AddCommentRequest) =
-        validate(request.todoId, commentId, request.password)
+        validate(request.memberId, request.todoId, commentId, request.password)
             .run { getComment(commentId).update(request) }
 
     @Transactional
     fun deleteComment(commentId: Long, request: DeleteCommentRequest) =
-        validate(request.todoId, commentId, request.password)
+        validate(request.memberId, request.todoId, commentId, request.password)
             .run { commentRepository.deleteById(commentId) }
 
     @Transactional
     fun deleteCommentsByTodoId(todoId: Long) = commentRepository.deleteAllCommentsByTodoId(todoId)
+
+    private fun getMember(memberId: Long) =
+        memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member")
 
     private fun getTodo(todoId: Long) =
         todoRepository.findByIdOrNull(todoId) ?: throw ModelNotFoundException("Todo")
@@ -47,9 +53,12 @@ class CommentService(
     private fun getComment(commentId: Long) =
         commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment")
 
-    private fun validate(todoId: Long, commentId: Long, password: String) {
-        val comment = getComment(commentId)
-        if (!todoRepository.existsById(todoId)) throw ModelNotFoundException("Todo")
-        else if (password != comment.password) throw WrongCommentPasswordException()
+    private fun validate(memberId: Long, todoId: Long, commentId: Long, password: String) {
+        getComment(commentId)
+            .let {
+                if (memberId != it.member.id) throw ModelNotFoundException("Member")
+                else if (todoId != it.todo.id) throw ModelNotFoundException("Todo")
+                else if (password != it.password) throw WrongCommentPasswordException()
+            }
     }
 }


### PR DESCRIPTION
#39 

- Member와 Comment 사이에 연관관계 설정 (1:n 단방향)
    - AddCommentRequest와 DeleteCommentRequest의 to메서드 수정
- AddCommentRequest와 DeleteCommentRequest에서 memberId를 파라미터로 받음
- CommentService의 validate 메서드 수정
    - memberId도 파라미터로 받아, 해당 Comment와 요청 객체의 memberId, todoId, password를 비교
- CommentResponse에서 Comment 작성자의 이름(name)도 제공하도록 수정