### PR TITLE
Feat: 랜덤 닉네임 생성 기능 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/SignUpRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/SignUpRequest.kt
@@ -3,6 +3,7 @@ package org.hunzz.todoapplication.domain.member.dto.request
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import org.hunzz.todoapplication.domain.member.model.Member
+import org.hunzz.todoapplication.global.util.NicknameGenerator.generateNickname
 
 data class SignUpRequest(
 //    @NotBlank(message = "Name is required.")
@@ -17,5 +18,5 @@ data class SignUpRequest(
 //    )
     val password: String
 ) {
-    fun to() = Member(name, email, nickname, password)
+    fun to() = Member(name, email, nickname ?: generateNickname(), password)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/util/NickNameGenerator.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/util/NickNameGenerator.kt
@@ -1,0 +1,16 @@
+package org.hunzz.todoapplication.global.util
+
+object NicknameGenerator {
+    private val adjectives =
+        listOf(
+            "갸냘픈", "거센", "게으른", "건방진", "고달픈", "너그러운", "더러운", "뜨거운", "못생긴", "배고픈",
+            "아름다운", "아픈", "약한", "잘생긴", "재미있는", "즐거운", "짓궂은", "탐욕스러운", "탐스러운", "힘찬"
+        )
+    private val animals =
+        listOf(
+            "강아지", "개구리", "고양이", "공룡", "노루", "돌고래", "멧돼지", "백호", "병아리", "사슴",
+            "사자", "새우", "송아지", "얼룩말", "올챙이", "원숭이", "지렁이", "참새", "해파리", "호랑이"
+        )
+
+    fun generateNickname() = "${adjectives.random()} ${animals.random()}"
+}


### PR DESCRIPTION
#41 

- 회원가입 시, 닉네임을 미지정한 경우 랜덤한 닉네임을 생성하는 기능 구현
- global>util 패키지에 NickNameGenerator Object 생성
- SignUpRequest에서 nickname이 null인 경우 generateNickname 함수 호출