### PR TITLE
Feat/#47: 비밀번호 저장 시 암호화 과정 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/dto/request/AddCommentRequest.kt
@@ -3,6 +3,7 @@ package org.hunzz.todoapplication.domain.comment.dto.request
 import org.hunzz.todoapplication.domain.comment.model.Comment
 import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.todo.model.Todo
+import org.hunzz.todoapplication.global.util.PasswordEncoder
 
 data class AddCommentRequest(
     val memberId: Long,
@@ -10,5 +11,5 @@ data class AddCommentRequest(
     val content: String,
     val password: String
 ) {
-    fun to(todo: Todo, member: Member) = Comment(content, password, todo, member)
+    fun to(todo: Todo, member: Member) = Comment(content, PasswordEncoder.encode(password), todo, member)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/model/Comment.kt
@@ -5,6 +5,7 @@ import org.hunzz.todoapplication.domain.comment.dto.request.AddCommentRequest
 import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.todo.model.Todo
 import org.hunzz.todoapplication.global.entity.BaseEntity
+import org.hunzz.todoapplication.global.util.PasswordEncoder
 
 @Entity
 @Table(name = "comments")
@@ -35,6 +36,5 @@ class Comment(
 
     fun update(request: AddCommentRequest) {
         this.content = request.content
-        this.password = request.password
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/comment/service/CommentService.kt
@@ -8,6 +8,7 @@ import org.hunzz.todoapplication.domain.member.repository.MemberRepository
 import org.hunzz.todoapplication.domain.todo.repository.TodoRepository
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
 import org.hunzz.todoapplication.global.exception.WrongCommentPasswordException
+import org.hunzz.todoapplication.global.util.PasswordEncoder
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -58,7 +59,7 @@ class CommentService(
             .let {
                 if (memberId != it.member.id) throw ModelNotFoundException("Member")
                 else if (todoId != it.todo.id) throw ModelNotFoundException("Todo")
-                else if (password != it.password) throw WrongCommentPasswordException()
+                else if (password != PasswordEncoder.decode(it.password)) throw WrongCommentPasswordException()
             }
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/SignUpRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/SignUpRequest.kt
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.global.util.NicknameGenerator.generateNickname
+import org.hunzz.todoapplication.global.util.PasswordEncoder
 
 data class SignUpRequest(
 //    @NotBlank(message = "Name is required.")
@@ -18,5 +19,6 @@ data class SignUpRequest(
 //    )
     val password: String
 ) {
-    fun to() = Member(name, email, nickname ?: generateNickname(), password)
+    fun to() =
+        Member(name, email, nickname ?: generateNickname(), PasswordEncoder.encode(password))
 }


### PR DESCRIPTION
#47 

- 비밀번호를 암호화/복호화하는 PasswordEncoder Object 생성
- signup(회원가입) 시, 비밀번호를 암호화하여 저장
    - SignUpRequest에서 encode 수행
- addComment(댓글 작성) 시, 비밀번호를 암호화하여 저장
    - AddCommentRequest에서 encode 수행
    - 댓글 수정 및 삭제 시, request의 비밀번호와 기존 Comment의 비밀번호를 decode 하여 비교