### PR TITLE
Feat/#54: 로그인 기능 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/controller/MemberController.kt
@@ -1,7 +1,9 @@
 package org.hunzz.todoapplication.domain.member.controller
 
 import jakarta.validation.Valid
+import org.hunzz.todoapplication.domain.member.dto.request.LoginRequest
 import org.hunzz.todoapplication.domain.member.dto.request.SignUpRequest
+import org.hunzz.todoapplication.domain.member.dto.response.JwtResponse
 import org.hunzz.todoapplication.domain.member.service.MemberService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -15,9 +17,13 @@ import java.net.URI
 class MemberController(
     private val memberService: MemberService
 ) {
-    @PostMapping
-    fun signUp(@RequestBody request: SignUpRequest): ResponseEntity<Unit> =
+    @PostMapping("/signup")
+    fun signUp(@RequestBody @Valid request: SignUpRequest): ResponseEntity<Unit> =
         ResponseEntity.created(
             URI.create("/api/v1/members/${memberService.signUp(request)}")
         ).build()
+
+    @PostMapping("/login")
+    fun login(@RequestBody loginRequest: LoginRequest) =
+        ResponseEntity.ok(memberService.login(loginRequest))
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/LoginRequest.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/request/LoginRequest.kt
@@ -1,0 +1,9 @@
+package org.hunzz.todoapplication.domain.member.dto.request
+
+import org.hunzz.todoapplication.domain.member.model.MemberRole
+
+data class LoginRequest(
+    val email: String,
+    val password: String,
+    val role: MemberRole
+)

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/response/JwtResponse.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/dto/response/JwtResponse.kt
@@ -1,0 +1,6 @@
+package org.hunzz.todoapplication.domain.member.dto.response
+
+data class JwtResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/Member.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/Member.kt
@@ -29,6 +29,7 @@ class Member(
     @Column(name = "password")
     var password = password
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role")
     var role = role
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/MemberRole.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/MemberRole.kt
@@ -1,0 +1,5 @@
+package org.hunzz.todoapplication.domain.member.model
+
+enum class MemberRole {
+    MEMBER, ADMIN
+}

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/repository/MemberRepository.kt
@@ -4,4 +4,5 @@ import org.hunzz.todoapplication.domain.member.model.Member
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
+    fun findByEmail(email: String): Member?
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/service/MemberService.kt
@@ -1,14 +1,43 @@
 package org.hunzz.todoapplication.domain.member.service
 
+import org.hunzz.todoapplication.domain.member.dto.request.LoginRequest
 import org.hunzz.todoapplication.domain.member.dto.request.SignUpRequest
+import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.member.repository.MemberRepository
+import org.hunzz.todoapplication.global.exception.InvalidCredentialException
+import org.hunzz.todoapplication.global.exception.ModelNotFoundException
+import org.hunzz.todoapplication.global.exception.InvalidPasswordException
+import org.hunzz.todoapplication.global.security.jwt.JwtProvider
+import org.hunzz.todoapplication.global.util.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberService(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val jwtProvider: JwtProvider
 ) {
     @Transactional
-    fun signUp(request: SignUpRequest) = memberRepository.save(request.to()).id!!
+    fun signUp(request: SignUpRequest) =
+        memberRepository.save(request.to()).id!!
+
+    @Transactional
+    fun login(request: LoginRequest) =
+        getMemberByEmail(request.email)
+            .let {
+                validateLoginRequest(it, request)
+                jwtProvider.provideToken(
+                    subject = it.id.toString(),
+                    email = it.email,
+                    role = it.role.name
+                )
+            }
+
+    private fun getMemberByEmail(email: String) =
+        memberRepository.findByEmail(email) ?: throw ModelNotFoundException("Member")
+
+    private fun validateLoginRequest(member: Member, request: LoginRequest) {
+        if (member.role != request.role) throw InvalidCredentialException()
+        else if (PasswordEncoder.decode(member.password) != request.password) throw InvalidPasswordException()
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
@@ -8,9 +8,12 @@ class GlobalExceptionHandler {
     fun handleModelNotFoundException(e: ModelNotFoundException) =
         ResponseEntity.badRequest().body(e.message)
 
-    fun handleWrongCriteriaException(e: WrongCriteriaException) =
+    fun handleInvalidCriteriaException(e: InvalidCriteriaException) =
         ResponseEntity.badRequest().body(e.message)
 
-    fun handleWrongCommentPasswordException(e: WrongCommentPasswordException) =
+    fun handleInvalidPasswordException(e: InvalidPasswordException) =
+        ResponseEntity.badRequest().body(e.message)
+
+    fun handleInvalidCredentialException(e: InvalidCredentialException) =
         ResponseEntity.badRequest().body(e.message)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/InvalidCredentialException.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/InvalidCredentialException.kt
@@ -1,0 +1,3 @@
+package org.hunzz.todoapplication.global.exception
+
+class InvalidCredentialException() : RuntimeException("Invalid Credential.")

--- a/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/JwtProvider.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/JwtProvider.kt
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
+import org.hunzz.todoapplication.domain.member.dto.response.JwtResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
@@ -28,7 +29,7 @@ class JwtProvider(
     }
 
     // 토큰 생성
-    fun createToken(subject: String, email: String, role: String, exp: Long) =
+    private fun createToken(subject: String, email: String, role: String, exp: Long) =
         Jwts.builder()
             .subject(subject)
             .issuer(issuer)
@@ -37,6 +38,13 @@ class JwtProvider(
             .claims(getClaim(email, role))
             .signWith(getKey())
             .compact()
+
+    // 토큰 발급
+    fun provideToken(subject: String, email: String, role: String) =
+        JwtResponse(
+            accessToken = createToken(subject, email, role, accessTokenExpirationHour),
+            refreshToken = createToken(subject, email, role, refreshTokenExpirationHour)
+        )
 
     private fun getClaim(email: String, role: String) =
         Jwts.claims().add(mapOf("email" to email, "role" to role)).build()


### PR DESCRIPTION
#54 

- MemberController와 MemberService 클래스에 login 메서드 추가
- 로그인 시 이메일, 패스워드, 역할을 받아올 LoginRequest 클래스 생성
- MemberService에서 로그인 검증 로직 구현
    - 이메일, 패스워드, 역할 모두 검증 후 로그인
    - 예외 케이스 추가 (역할 검증 실패 시, InvalidCredentialException을 던짐)
- 로그인이 완료된 후 AccessToken과 RefreshToken을 발급을 위한 JwtResponse 클래스 생성
- JwtProvider 클래스 리팩토링
    - 토큰 생성은 내부 메서드(createToken)로 분리, 토큰 발급만 외부로부터 가능
- Member 엔티티의 role 속성에 누락된 Enumerated 어노테이션 추가