### PR TITLE
Feat/#57: 회원탈퇴 기능 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/controller/MemberController.kt
@@ -3,9 +3,10 @@ package org.hunzz.todoapplication.domain.member.controller
 import jakarta.validation.Valid
 import org.hunzz.todoapplication.domain.member.dto.request.LoginRequest
 import org.hunzz.todoapplication.domain.member.dto.request.SignUpRequest
-import org.hunzz.todoapplication.domain.member.dto.response.JwtResponse
 import org.hunzz.todoapplication.domain.member.service.MemberService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -26,4 +27,10 @@ class MemberController(
     @PostMapping("/login")
     fun login(@RequestBody loginRequest: LoginRequest) =
         ResponseEntity.ok(memberService.login(loginRequest))
+
+    @DeleteMapping("/{memberId}")
+    fun withdrawal(@PathVariable memberId: Long): ResponseEntity<Unit> {
+        memberService.withdrawal(memberId)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/Member.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/Member.kt
@@ -20,10 +20,10 @@ class Member(
     @Column(name = "name")
     var name = name
 
-    @Column(name = "email", unique = true)
+    @Column(name = "email")
     var email = email
 
-    @Column(name = "nickname", unique = true)
+    @Column(name = "nickname")
     var nickname = nickname
 
     @Column(name = "password")
@@ -32,4 +32,11 @@ class Member(
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     var role = role
+
+    fun updateForWithdrawal() {
+        this.name = "탈퇴한 회원"
+        this.nickname = null
+        this.password = ""
+//        this.role = MemberRole.WITHDRAWN
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/MemberRole.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/model/MemberRole.kt
@@ -1,5 +1,5 @@
 package org.hunzz.todoapplication.domain.member.model
 
 enum class MemberRole {
-    MEMBER, ADMIN
+    MEMBER, ADMIN, WITHDRAWN
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/member/service/MemberService.kt
@@ -4,17 +4,20 @@ import org.hunzz.todoapplication.domain.member.dto.request.LoginRequest
 import org.hunzz.todoapplication.domain.member.dto.request.SignUpRequest
 import org.hunzz.todoapplication.domain.member.model.Member
 import org.hunzz.todoapplication.domain.member.repository.MemberRepository
+import org.hunzz.todoapplication.domain.todo.service.TodoService
 import org.hunzz.todoapplication.global.exception.InvalidCredentialException
 import org.hunzz.todoapplication.global.exception.ModelNotFoundException
 import org.hunzz.todoapplication.global.exception.InvalidPasswordException
 import org.hunzz.todoapplication.global.security.jwt.JwtProvider
 import org.hunzz.todoapplication.global.util.PasswordEncoder
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
+    private val todoService: TodoService,
     private val jwtProvider: JwtProvider
 ) {
     @Transactional
@@ -32,6 +35,14 @@ class MemberService(
                     role = it.role.name
                 )
             }
+
+    @Transactional
+    fun withdrawal(memberId: Long) =
+        todoService.deleteAllTodosWithMemberId(memberId)
+            .run { getMemberById(memberId).updateForWithdrawal() }
+
+    private fun getMemberById(id: Long) =
+        memberRepository.findByIdOrNull(id) ?: throw ModelNotFoundException("Member")
 
     private fun getMemberByEmail(email: String) =
         memberRepository.findByEmail(email) ?: throw ModelNotFoundException("Member")

--- a/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/domain/todo/service/TodoService.kt
@@ -33,7 +33,8 @@ class TodoService(
         }
 
     @Transactional
-    fun findTodo(todoId: Long) = TodoResponse.from(getTodo(todoId), getAllCommentsByTodoId(todoId))
+    fun findTodo(todoId: Long) =
+        TodoResponse.from(getTodo(todoId), getAllCommentsByTodoId(todoId))
 
     @Transactional
     fun addTodo(request: AddTodoRequest) =
@@ -50,6 +51,12 @@ class TodoService(
     @Transactional
     fun deleteTodo(todoId: Long) =
         deleteAllCommentsByTodoId(todoId).run { todoRepository.deleteById(todoId) }
+
+    @Transactional
+    fun deleteAllTodosWithMemberId(memberId: Long) =
+        todoRepository.findAll()
+            .filter { it.member.id == memberId }
+            .forEach { deleteTodo(it.id!!) }
 
     private fun getMember(memberId: Long) =
         memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member")


### PR DESCRIPTION
#57 

- MemberController와 MemberService에 withdrawal 메서드 생성
- TodoService에서 deleteAllTodosWithMemberId 메서드 생성
    - 해당 멤버가 작성한 Todo는 모두 삭제
    - 기존에 TodoService에 만들어놓은 deleteTodo 메서드 사용
- MemberRole에 WITHDRAWAN 역할 추가
- Member에 updateForWithdrawal 메서드 생성
    - 해당 멤버가 탈퇴하면, 이름은 "탈퇴한 회원", 닉네임은 null, 패스워드는 "", 역할은 WITHDRAWN으로 설정