### PR TITLE
Feat/#61: JWT 검증 및 인증 과정 구현

### DIFF
--- a/src/main/kotlin/org/hunzz/todoapplication/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/config/SecurityConfig.kt
@@ -1,20 +1,37 @@
 package org.hunzz.todoapplication.global.config
 
+import org.hunzz.todoapplication.global.security.filter.JwtAuthenticationFilter
+import org.hunzz.todoapplication.global.security.jwt.CustomAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val authenticationEntryPoint: CustomAuthenticationEntryPoint
+) {
     @Bean
     fun filterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
         return httpSecurity
             .httpBasic { it.disable() } // BasicAuthenticationFilter 제외
             .formLogin { it.disable() } // UsernamePasswordAuthenticationFilter, DefaultLoginPageGenerationFilter, DefaultLogoutPageGenerationFilter 제외
             .csrf { it.disable() } // CSRFFilter 제외
+            .headers { it.frameOptions { foc -> foc.disable() } } // iframe 차단 해제 (H2-Console 사용을 위한)
+            .authorizeHttpRequests {
+                it.requestMatchers(
+                    "/api/v1/members/login", "api/v1/members/signup", "/swagger-ui/**", "/v3/api-docs/**"
+                ).permitAll() // 인증 과정이 필요 없는 특정 URI 설정
+                    .anyRequest().authenticated() // 나머지 URI에 대해서는 인증 요구
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java) // 필터 위치 지정
+            .exceptionHandling {
+                it.authenticationEntryPoint(authenticationEntryPoint)
+            } // 에러 처리 (status code를 403이 아닌 401로 처리하기 위한)
             .build()
     }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/config/SwaggerConfig.kt
@@ -3,18 +3,35 @@ package org.hunzz.todoapplication.global.config
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SwaggerConfig {
     @Bean
-    fun openapi(): OpenAPI = OpenAPI()
-        .components(Components())
-        .info(
-            Info()
-                .title("TODO API")
-                .description("TODO API Schema")
-                .version("1.0.0")
-        )
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .addSecurityItem(
+                SecurityRequirement().addList("Bearer Authentication")
+            )
+            .components(
+                Components().addSecuritySchemes(
+                    "Bearer Authentication",
+                    SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                        .`in`(SecurityScheme.In.HEADER)
+                        .name("Authorization")
+                )
+            )
+            .info(
+                Info()
+                    .title("TODO API")
+                    .description("TODO API schema")
+                    .version("1.0.0")
+            )
+    }
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package org.hunzz.todoapplication.global.exception
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -21,4 +22,8 @@ class GlobalExceptionHandler {
     @ExceptionHandler(InvalidCredentialException::class)
     fun handleInvalidCredentialException(e: InvalidCredentialException) =
         ResponseEntity.badRequest().body(e.message)
+
+    @ExceptionHandler(InvalidJwtException::class)
+    fun handleInvalidAccessException(e: InvalidJwtException) =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.message)
 }

--- a/src/main/kotlin/org/hunzz/todoapplication/global/exception/InvalidJwtException.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/exception/InvalidJwtException.kt
@@ -1,0 +1,3 @@
+package org.hunzz.todoapplication.global.exception
+
+class InvalidJwtException: RuntimeException("Invalid Jwt.")

--- a/src/main/kotlin/org/hunzz/todoapplication/global/security/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/security/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,52 @@
+package org.hunzz.todoapplication.global.security.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.hunzz.todoapplication.global.exception.InvalidJwtException
+import org.hunzz.todoapplication.global.security.jwt.JwtAuthenticationToken
+import org.hunzz.todoapplication.global.security.jwt.JwtProvider
+import org.hunzz.todoapplication.global.security.jwt.MemberPrincipal
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtProvider: JwtProvider
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        getBearerToken(request)
+            ?.let {
+                jwtProvider.validateToken(it)
+                    .onSuccess { jws ->
+                        val memberId = jws.payload.subject.toLong()
+                        val email = jws.payload.get("email", String::class.java)
+                        val role = jws.payload.get("role", String::class.java)
+                        val authentication = JwtAuthenticationToken(
+                            principal = MemberPrincipal(
+                                id = memberId,
+                                email = email,
+                                roles = setOf(role)
+                            ),
+                            details = WebAuthenticationDetailsSource().buildDetails(request)
+                        )
+                        SecurityContextHolder.getContext().authentication = authentication
+                    }
+                    .onFailure { throw InvalidJwtException() }
+            } ?: throw Exception()
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun getBearerToken(request: HttpServletRequest): String? {
+        val header = request.getHeader(HttpHeaders.AUTHORIZATION) ?: null // Bearer {JWT}
+        return header?.split(" ")?.get(1)
+    }
+}

--- a/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,21 @@
+package org.hunzz.todoapplication.global.security.jwt
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+    }
+}

--- a/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/JwtAuthenticationToken.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/JwtAuthenticationToken.kt
@@ -1,0 +1,17 @@
+package org.hunzz.todoapplication.global.security.jwt
+
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.web.authentication.WebAuthenticationDetails
+
+class JwtAuthenticationToken(
+    private val principal: MemberPrincipal,
+    details: WebAuthenticationDetails
+) : AbstractAuthenticationToken(principal.authorities) {
+    init {
+        super.setAuthenticated(true)
+        super.setDetails(details)
+    }
+
+    override fun getCredentials() = null
+    override fun getPrincipal() = principal
+}

--- a/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/MemberPrincipal.kt
+++ b/src/main/kotlin/org/hunzz/todoapplication/global/security/jwt/MemberPrincipal.kt
@@ -1,0 +1,14 @@
+package org.hunzz.todoapplication.global.security.jwt
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+data class MemberPrincipal(
+    val id: Long,
+    val email: String,
+    val authorities: Collection<GrantedAuthority>
+) {
+    constructor(id: Long, email: String, roles: Set<String>) : this(
+        id, email, roles.map { SimpleGrantedAuthority("ROLE_$it") }
+    )
+}


### PR DESCRIPTION
#61 

- JwtAuthenticaitonFilter 생성
    - getBearerToken 메서드를 생성하여 토큰을 받아옴
    - JwtProvider 객체를 주입 받아 validateToken 메서드를 사용하여 요청으로 넘어온 토큰을 검증
    - 테스트 케이스 추가 (InvalidJwtException)
    - 유효하지 않은 토큰일 경우 InvalidJwtException 예외 처리
- 인증 처리를 위한 JwtAuthenticationToken 클래스와 MemberPrincipal 클래스 생성
- CustomAuthenticationEntryPoint 클래스 생성
    - 인증 절차를 밟지 않은 경우 403이 아닌 401 에러 코드를 리턴
- SecurityConfig 클래스 수정
    - 인증 과정이 필요한/필요없는 URI를 구분
    - JwtAuthenticationFilter, CustomAuthenticaitonEntryPoint 작동
- API에 대한 인증 과정 테스트를 위한 SwaggerConfig 클래스 수정